### PR TITLE
feat: 新增後臺管理主頁、傳圖報價功能

### DIFF
--- a/backend/prisma/migrations/20260412082810_revise_quote_request_status/migration.sql
+++ b/backend/prisma/migrations/20260412082810_revise_quote_request_status/migration.sql
@@ -1,0 +1,16 @@
+/*
+  Warnings:
+
+  - The values [quoted,accepted,rejected] on the enum `quote_status` will be removed. If these variants are still used in the database, this will fail.
+
+*/
+-- AlterEnum
+BEGIN;
+CREATE TYPE "quote_status_new" AS ENUM ('pending', 'confirmed', 'completed', 'cancelled', 'noshow');
+ALTER TABLE "public"."quote_requests" ALTER COLUMN "status" DROP DEFAULT;
+ALTER TABLE "quote_requests" ALTER COLUMN "status" TYPE "quote_status_new" USING ("status"::text::"quote_status_new");
+ALTER TYPE "quote_status" RENAME TO "quote_status_old";
+ALTER TYPE "quote_status_new" RENAME TO "quote_status";
+DROP TYPE "public"."quote_status_old";
+ALTER TABLE "quote_requests" ALTER COLUMN "status" SET DEFAULT 'pending';
+COMMIT;

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -300,9 +300,10 @@ enum avatar_source_type {
 
 enum quote_status {
   pending
-  quoted
-  accepted
-  rejected
+  confirmed
+  completed
+  cancelled
+  noshow
 }
 
 enum schedule_status {

--- a/backend/src/controllers/appointment.controller.ts
+++ b/backend/src/controllers/appointment.controller.ts
@@ -8,13 +8,19 @@ const AppointmentHandler = {
       const page = req.query.page ? Number(req.query.page) : 1;
       const limit = req.query.limit ? Number(req.query.limit) : 10;
       const queryDate = new Date(Number(startFrom));
+      const isTilNow = JSON.parse(req.query.isTilNow as string);
+      const pagination = {
+        page,
+        limit,
+      };
       if (isNaN(queryDate.getTime())) {
         return res.status(400).json({ message: "無效的時間格式" });
       }
-      const result = await AppointmentService.getAppointmentsByTime(queryDate, {
-        page: Number(page),
-        limit: Number(limit),
-      });
+      const result = await AppointmentService.getAppointmentsByTime(
+        queryDate,
+        isTilNow,
+        pagination
+      );
       res.json(result);
     } catch (err) {
       res.status(500).json({ message: "server error", err });

--- a/backend/src/controllers/quote.controller.ts
+++ b/backend/src/controllers/quote.controller.ts
@@ -1,0 +1,35 @@
+import { Request, Response } from "express";
+import { QuoteRequestService } from "src/services/quote.service";
+
+const QuoteRequestHandler = {
+  async getQuoteRquest(req: Request, res: Response) {
+    const page = Number(req.query.page);
+    const limit = Number(req.query.limit);
+    try {
+      const quoteRequset = await QuoteRequestService.getQuoteRequest({
+        page,
+        limit,
+      });
+      return res.status(200).json(quoteRequset);
+    } catch (err) {
+      const errorMessage = err instanceof Error ? err.message : "資料獲取失敗";
+      return res.status(400).json({ error: errorMessage });
+    }
+  },
+  async updateQuoteRequest(req: Request, res: Response) {
+    try {
+      const { id, staffReply, price } = req.body;
+      const updatedData = await QuoteRequestService.updatequoteRequest(
+        id,
+        staffReply,
+        price
+      );
+      return res.status(200).json(updatedData);
+    } catch (err) {
+      const errorMessage = err instanceof Error ? err.message : "資料獲取失敗";
+      return res.status(400).json({ error: errorMessage });
+    }
+  },
+};
+
+export { QuoteRequestHandler };

--- a/backend/src/routes/appointment.ts
+++ b/backend/src/routes/appointment.ts
@@ -10,7 +10,11 @@ router.patch(
   isAdmin,
   AppointmentHandler.changeStatusByAdmin
 );
-router.get("/user", AppointmentHandler.getAppointmentListByUser);
+router.get(
+  "/user",
+  authMiddleWare,
+  AppointmentHandler.getAppointmentListByUser
+);
 router.get("/staff", AppointmentHandler.getAppointmentListByStaff);
 router.post("/", AppointmentHandler.createNewAppointment);
 router.patch(

--- a/backend/src/routes/index.ts
+++ b/backend/src/routes/index.ts
@@ -7,6 +7,7 @@ import authRouter from "./auth";
 import userRouter from "./user";
 import uploadImageRouter from "./upload";
 import galleyRouter from "./gallery";
+import quoteRouter from "./quote";
 
 const rootRouter = Router();
 
@@ -18,5 +19,6 @@ rootRouter.use("/auth", authRouter);
 rootRouter.use("/user", userRouter);
 rootRouter.use("/upload", uploadImageRouter);
 rootRouter.use("/gallery", galleyRouter);
+rootRouter.use("/quote", quoteRouter);
 
 export default rootRouter;

--- a/backend/src/routes/quote.ts
+++ b/backend/src/routes/quote.ts
@@ -1,0 +1,15 @@
+import Router from "express";
+import { QuoteRequestHandler } from "../controllers/quote.controller";
+import { isAdmin, authMiddleWare } from "../middlewares/auth.middleware";
+
+const router = Router();
+
+router.get("/", authMiddleWare, isAdmin, QuoteRequestHandler.getQuoteRquest);
+router.post(
+  "/update",
+  authMiddleWare,
+  isAdmin,
+  QuoteRequestHandler.updateQuoteRequest
+);
+
+export default router;

--- a/backend/src/routes/schedule.ts
+++ b/backend/src/routes/schedule.ts
@@ -1,5 +1,6 @@
 import { SchedulesHandler } from "../controllers/schedule.controller";
 import { Router } from "express";
+import { isAdmin } from "src/middlewares/auth.middleware";
 import multer from "multer";
 
 const router = Router();
@@ -23,7 +24,16 @@ const upload = multer({
 
 router.get("/", SchedulesHandler.getScheduleList);
 router.get("/:staffId", SchedulesHandler.getScheduleListByStaff);
-router.post("/upload", upload.single("file"), SchedulesHandler.uploadSchedule);
-router.post("/:staffId/:workDate/cancel", SchedulesHandler.cancelSchedule);
+router.post(
+  "/upload",
+  isAdmin,
+  upload.single("file"),
+  SchedulesHandler.uploadSchedule
+);
+router.post(
+  "/:staffId/:workDate/cancel",
+  isAdmin,
+  SchedulesHandler.cancelSchedule
+);
 
 export default router;

--- a/backend/src/services/appointment.service.ts
+++ b/backend/src/services/appointment.service.ts
@@ -1,6 +1,6 @@
 import { prisma } from "../lib/prisma.js";
 import { appointment_status, quote_status } from "../generated/prisma/index.js";
-import { pushLineNotification } from "./lineMessage.service.js";
+import { pushAppointmentNotification } from "./lineMessage.service.js";
 
 export interface AppointmentItem {
   service_id: number;
@@ -54,12 +54,31 @@ export interface PaginationQuery {
 }
 
 const AppointmentService = {
-  async getAppointmentsByTime(time: Date, pagination: PaginationQuery = {}) {
+  async getAppointmentsByTime(
+    time: Date,
+    isTilNow: boolean,
+    pagination: PaginationQuery = {}
+  ) {
     if (!time) {
       throw new Error("未選定時間區間");
     }
-    if (time.getTime() > Date.now()) {
-      throw new Error("不得回傳超過現在時刻之時間");
+    let whereCondition;
+
+    if (isTilNow) {
+      const startOfDay = new Date();
+      startOfDay.setHours(0, 0, 0, 0);
+
+      const endOfDay = new Date();
+      endOfDay.setHours(23, 59, 59, 999);
+
+      whereCondition = {
+        gte: startOfDay,
+        lte: endOfDay,
+      };
+    } else {
+      whereCondition = {
+        gte: time,
+      };
     }
 
     const page = Number(pagination.page) || 1;
@@ -68,13 +87,13 @@ const AppointmentService = {
 
     try {
       const [data, total] = await Promise.all([
-        //可以同時發送兩個獨立的資料庫請求（取資料與算總數），而不是一個接著一個做
+        //all可以同時發送兩個獨立的資料庫請求（取資料與算總數），而不是一個接著一個做
         prisma.appointments.findMany({
           orderBy: { start_time: "desc" },
           skip: skip,
           take: limit,
           where: {
-            start_time: { gte: time },
+            start_time: whereCondition,
           },
           include: {
             staff: {
@@ -101,7 +120,7 @@ const AppointmentService = {
         }),
         prisma.appointments.count({
           //計算總筆數
-          where: { start_time: { gte: time } },
+          where: { start_time: whereCondition },
         }),
       ]);
       return {
@@ -256,98 +275,91 @@ const AppointmentService = {
       throw new Error("日期格式錯誤，無法解析時間");
     }
 
-    // 檢查美甲師時段是否衝突
-    const conflict = await prisma.appointments.findFirst({
-      where: {
-        staff_id: data.staff_id,
-        status: { not: appointment_status.cancelled },
-        start_time: { lt: endDate }, // 現有預約的開始時間在新預約結束時間之前
-        end_time: { gt: startDate }, // 現有預約的結束時間在新預約開始時間之前
-        // 兩個條件都成立的話就是衝突
-      },
-    });
-    if (conflict) {
-      throw new Error("該時段美甲師已被預約");
-    }
-
-    // 執行寫入
-    const newAppointment = await prisma.appointments.create({
-      data: {
-        start_time: startDate,
-        end_time: endDate,
-        total_price: data.total_price,
-        staff_id: BigInt(data.staff_id),
-        user_id: data.user_id ? BigInt(data.user_id) : null, // 保留訪客預約的可能
-        note: data.note,
-        status: data.status,
-        appointment_items: {
-          create: data.appointment_items.map((item) => ({
-            // 包個()表示是要回傳整個物件，而不是執行{}中的指令
-            service_id: Number(item.service_id),
-            service_price_id: Number(item.service_price_id),
-            price_snapshot: Number(item.price_snapshot),
-            duration_snapshot: Number(item.duration_snapshot),
-
-            // 這裡處理該項目對應的加購
-            appointment_addons: {
-              create: (item.appointment_addons || []).map((addon) => ({
-                addon_id: Number(addon.addon_id),
-                price_snapshot: Number(addon.price_snapshot),
-                duration_snapshot: Number(addon.duration_snapshot),
-                quantity: Number(addon.quantity || 1),
-                // 這裡不需要手動傳 appointment_id，Prisma 會幫處理
-              })),
-            },
-          })),
+    const newAppointment = await prisma.$transaction(async (tx) => {
+      // 檢查時段衝突
+      const conflict = await tx.appointments.findFirst({
+        where: {
+          staff_id: data.staff_id,
+          status: { not: "cancelled" },
+          start_time: { lt: endDate },
+          end_time: { gt: startDate },
         },
-        ...(data.quote_request && {
-          quote_requests: {
-            create: {
-              user_id: data.user_id ? BigInt(data.user_id) : null,
-              staff_id: BigInt(data.staff_id),
-              image_url: data.quote_request.image_url,
-              description: data.quote_request.description,
-              status: quote_status.pending,
-            },
-          },
-        }),
-      },
-      include: {
-        quote_requests: true,
-        appointment_items: {
-          include: {
-            appointment_addons: true,
+      });
+
+      if (conflict) throw new Error("該時段美甲師已被預約");
+
+      // 建立預約主表與項目清單
+      const appointment = await tx.appointments.create({
+        data: {
+          start_time: startDate,
+          end_time: endDate,
+          total_price: data.total_price,
+          staff_id: BigInt(data.staff_id),
+          user_id: data.user_id ? BigInt(data.user_id) : null,
+          note: data.note,
+          status: data.status,
+          appointment_items: {
+            create: data.appointment_items.map((item) => ({
+              service_id: Number(item.service_id),
+              service_price_id: Number(item.service_price_id),
+              price_snapshot: Number(item.price_snapshot),
+              duration_snapshot: Number(item.duration_snapshot),
+              appointment_addons: {
+                create: (item.appointment_addons || []).map((addon) => ({
+                  addon_id: Number(addon.addon_id),
+                  price_snapshot: Number(addon.price_snapshot),
+                  duration_snapshot: Number(addon.duration_snapshot),
+                  quantity: Number(addon.quantity || 1),
+                })),
+              },
+            })),
           },
         },
-      },
+        include: {
+          appointment_items: {
+            include: { appointment_addons: true },
+          },
+        },
+      });
+
+      // 如果有詢價需求，手動建立並連結 appointment_id
+      if (data.quote_request && data.quote_request.image_url) {
+        await tx.quote_requests.create({
+          data: {
+            user_id: data.user_id ? BigInt(data.user_id) : null,
+            staff_id: BigInt(data.staff_id),
+            image_url: data.quote_request.image_url,
+            description: data.quote_request.description || "",
+            status: "pending",
+            appointment_id: appointment.id,
+          },
+        });
+      }
+
+      return appointment;
     });
+
+    // 發送 LINE 通知
     const lineId = data.line_id;
     if (lineId) {
       const bookingItems = data.appointment_items.map((item) => {
         const dbPrice = dbPrices.find((p) => p.id === item.service_price_id);
-        const serviceName = dbPrice?.services?.name || "未知服務";
-        const addonDetails = (item.appointment_addons || []).map((addon) => {
-          const dbAddon = dbAddons.find((a) => a.id === addon.addon_id);
-          return {
-            name: dbAddon?.name || "未知服務",
-            quantity: addon.quantity || 1,
-          };
-        });
         return {
-          service_name: serviceName,
-          addons: addonDetails,
+          service_name: dbPrice?.services?.name || "未知服務",
+          addons: (item.appointment_addons || []).map((addon) => ({
+            name:
+              dbAddons.find((a) => a.id === addon.addon_id)?.name || "未知加購",
+            quantity: addon.quantity || 1,
+          })),
         };
       });
 
-      const startTime = new Date(data.start_time);
-      const bookingData = {
-        start_time: startTime,
+      pushAppointmentNotification(lineId, {
+        start_time: startDate,
         appointment_items: bookingItems,
-      };
-      await pushLineNotification(lineId, bookingData).catch((err) =>
-        console.error("LINE 通知發送失敗:", err)
-      );
+      }).catch((err) => console.error("LINE 通知失敗:", err));
     }
+
     return newAppointment;
   },
   async handleUserCancellation(id: number, userId: number) {
@@ -407,7 +419,20 @@ const AppointmentService = {
     if (currentAppointment.status === newStatus) return currentAppointment;
     return await prisma.appointments.update({
       where: { id: id },
-      data: { status: newStatus as appointment_status },
+      data: {
+        status: newStatus as appointment_status,
+        quote_requests: {
+          updateMany: {
+            where: { appointment_id: id },
+            data: {
+              status: newStatus as quote_status,
+            },
+          },
+        },
+      },
+      include: {
+        quote_requests: true,
+      },
     });
   },
 };

--- a/backend/src/services/lineMessage.service.ts
+++ b/backend/src/services/lineMessage.service.ts
@@ -9,23 +9,45 @@ export interface bookingData {
   }[];
 }
 
-const { MessagingApiClient } = messagingApi;
+interface Appointment {
+  user_id: number;
+  staff_id: number;
+  status: "pending" | "confirmed" | "completed" | "cancelled" | "noshow";
+  start_time: string;
+  end_time: string;
+  total_price: number;
+}
+interface User {
+  name: string;
+  line_id: string;
+}
+export interface QuoteRequest {
+  appointments: Appointment;
+  appointment_id: number;
+  users: User;
+  id: number;
+  created_at: Date;
+  user_id: number;
+  staff_id: number;
+  status: "pending" | "confirmed" | "completed" | "cancelled" | "noshow";
+  staff_reply: string;
+  replied_at: Date;
+  description: string;
+  image_url: string;
+  quoted_price: number;
+}
 
-const config = {
-  channelAccessToken: process.env.LINE_MESSAGE_ACCESS_TOKEN,
-  channelSecret: process.env.LINE_MESSAGE_CLIENT_SECRET,
-};
+const { MessagingApiClient } = messagingApi;
 
 const client = new MessagingApiClient({
   channelAccessToken: process.env.LINE_MESSAGE_ACCESS_TOKEN as string,
 });
 
-export const pushLineNotification = async (
+export const pushAppointmentNotification = async (
   lineId: string,
   data: bookingData
 ) => {
   if (!lineId) return;
-  console.log("驗證 ID:", lineId, "長度:", lineId?.length);
 
   const formattedTime = new Date(data.start_time).toLocaleString("zh-TW", {
     year: "numeric",
@@ -105,6 +127,120 @@ export const pushLineNotification = async (
         {
           type: "flex",
           altText: "您已預約服務",
+          contents: flexContainer,
+        },
+      ],
+    });
+  } catch (err: unknown) {
+    if (err instanceof Error) {
+      const errorWithBody = err as { body?: string };
+      if (errorWithBody.body) {
+        try {
+          const detail = JSON.parse(errorWithBody.body);
+          console.error("LINE API 錯誤細節:", JSON.stringify(detail, null, 2));
+        } catch {
+          console.error("無法解析的錯誤內容:", errorWithBody.body);
+        }
+      } else {
+        console.error("發送訊息失敗:", err.message);
+      }
+    } else {
+      console.error("發生未知類型錯誤:", err);
+    }
+  }
+};
+
+export const pushQuoteNotification = async (
+  lineId: string,
+  quote: QuoteRequest
+) => {
+  if (!lineId) return;
+
+  const formattedTime = new Date(quote.appointments.start_time).toLocaleString(
+    "zh-TW",
+    {
+      year: "numeric",
+      month: "2-digit",
+      day: "2-digit",
+      hour: "2-digit",
+      minute: "2-digit",
+      hour12: false,
+    }
+  );
+  const flexContainer: any = {
+    type: "bubble",
+    body: {
+      type: "box",
+      layout: "vertical",
+      contents: [
+        {
+          type: "text",
+          text: `親愛的${quote.users.name}，您好！`,
+          weight: "bold",
+          size: "lg",
+          color: "#EB5A8B",
+        },
+        {
+          type: "text",
+          text: "您預約的Milky Nail傳圖報價如下：",
+          weight: "bold",
+          size: "md",
+          color: "#EB5A8B",
+        },
+        { type: "separator", margin: "md" },
+        {
+          type: "box",
+          layout: "vertical",
+          margin: "md",
+          spacing: "sm",
+          contents: [
+            {
+              type: "text",
+              text: `預約時間：${formattedTime}`,
+              size: "sm",
+              color: "#E8306E",
+              weight: "bold",
+            },
+            {
+              type: "image",
+              url: quote.image_url,
+              size: "full",
+              aspectRatio: "20:13",
+              aspectMode: "cover",
+            },
+            {
+              type: "text",
+              text: `美甲師訊息：${quote.staff_reply}`,
+              size: "sm",
+              color: "#E8306E",
+              weight: "bold",
+            },
+            {
+              type: "text",
+              text: `價格：${quote.quoted_price}`,
+              size: "sm",
+              color: "#E8306E",
+              weight: "bold",
+            },
+            {
+              type: "text",
+              text: "期待您的到來～",
+              size: "sm",
+              color: "#E8306E",
+              weight: "bold",
+            },
+          ],
+        },
+      ],
+    },
+  };
+  try {
+    await client.pushMessage({
+      to: lineId,
+      messages: [
+        {
+          type: "flex",
+          altText: "已為您確認預約服務，以下是詳細資訊：",
           contents: flexContainer,
         },
       ],

--- a/backend/src/services/quote.service.ts
+++ b/backend/src/services/quote.service.ts
@@ -1,0 +1,106 @@
+import { prisma } from "../lib/prisma.js";
+import { pushQuoteNotification, QuoteRequest } from "./lineMessage.service.js";
+export interface PaginationQuery {
+  page?: number;
+  limit?: number;
+}
+const QuoteRequestService = {
+  async getQuoteRequest(pagination: PaginationQuery = {}) {
+    const page = Number(pagination.page) || 1;
+    const limit = Number(pagination.limit) || 10;
+    const skip = (page - 1) * limit;
+    try {
+      const quoteRequests = await prisma.quote_requests.findMany({
+        skip,
+        take: limit,
+        orderBy: { created_at: "desc" },
+        include: {
+          appointments: {
+            select: {
+              start_time: true,
+              end_time: true,
+              total_price: true,
+              staff_id: true,
+              user_id: true,
+              status: true,
+            },
+          },
+          users: {
+            select: {
+              name: true,
+            },
+          },
+        },
+      });
+      const totalCount = await prisma.quote_requests.count();
+      return { data: quoteRequests, totalCount };
+    } catch (err) {
+      if (err instanceof Error) {
+        const message = err instanceof Error ? err.message : "未知錯誤";
+        throw new Error(`獲取失敗：${message}`);
+      }
+    }
+  },
+
+  async updatequoteRequest(id: number, staffReply: string, price: number) {
+    const currQuote = await prisma.quote_requests.findUnique({
+      where: { id },
+      include: {
+        appointments: {
+          select: {
+            user_id: true,
+            staff_id: true,
+            status: true,
+            start_time: true,
+            end_time: true,
+            total_price: true,
+          },
+        },
+        users: {
+          select: {
+            name: true,
+            line_id: true,
+          },
+        },
+      },
+    });
+    const lineId = currQuote?.users?.line_id as string;
+    const numericPrice = Number(price); //所有的 URL 參數在後端解析時預設都是字串
+    if (!id || !staffReply.trim() || !price) {
+      throw new Error("缺少必要參數");
+    }
+    if (typeof numericPrice !== "number" || price <= 0) {
+      throw new Error("價格必須大於0元");
+    }
+    try {
+      const updatedData = await prisma.quote_requests.update({
+        where: { id },
+        data: {
+          staff_reply: staffReply.trim(),
+          quoted_price: numericPrice,
+          replied_at: new Date(),
+          appointments: {
+            update: {
+              total_price: numericPrice,
+            },
+          },
+        },
+      });
+
+      pushQuoteNotification(lineId, {
+        ...currQuote,
+        ...updatedData,
+      } as unknown as QuoteRequest);
+
+      return updatedData;
+    } catch (err) {
+      if (err instanceof Error) {
+        const message = err.message;
+        throw new Error(`更新失敗：${message}`);
+      }
+      throw new Error(`更新失敗：${err}`);
+    }
+  },
+};
+
+export { QuoteRequestService };

--- a/backend/src/services/user.service.ts
+++ b/backend/src/services/user.service.ts
@@ -108,7 +108,7 @@ const UserService = {
     if (!user) throw new Error("找不到使用者");
     return prisma.users.update({
       where: { id: BigInt(userId) },
-      data: { is_blocked: newStatus },
+      data: { is_blocked: newStatus }, //TODO:增加blocked_user欄位update
     });
   },
 };

--- a/frontend/src/api/appointment.ts
+++ b/frontend/src/api/appointment.ts
@@ -96,6 +96,7 @@ const createAppointment = (data: AppointmentData): Promise<AppointmentData> =>
 
 const getAppointmentByTime = async (
   targetDate: Date,
+  isTilNow: boolean,
   page = 1,
   limit = 10
 ): Promise<AppointmentResponse | null> => {
@@ -104,7 +105,7 @@ const getAppointmentByTime = async (
     const res = (await apiClient.get<AppointmentResponse>(
       `/appointments/search`,
       {
-        params: { startFrom: timestamp, page, limit },
+        params: { startFrom: timestamp, isTilNow, page, limit },
       }
     )) as unknown as AppointmentResponse;
     return res;

--- a/frontend/src/api/quote.ts
+++ b/frontend/src/api/quote.ts
@@ -1,0 +1,66 @@
+import apiClient from "./client";
+
+interface Appointment {
+  user_id: number;
+  staff_id: number;
+  status: "pending" | "confirmed" | "completed" | "cancelled" | "noshow";
+  start_time: string;
+  end_time: string;
+  total_price: number;
+}
+interface User {
+  name: string;
+  line_id: true;
+}
+export interface QuoteRequest {
+  appointments: Appointment;
+  appointment_id: number;
+  users: User;
+  id: number;
+  created_at: Date;
+  user_id: number;
+  staff_id: number;
+  status: "pending" | "confirmed" | "completed" | "cancelled" | "noshow";
+  staff_reply: string;
+  replied_at: Date;
+  description: string;
+  image_url: string;
+  quoted_price: number;
+}
+
+export interface QuoteRequestPagination {
+  data: QuoteRequest[];
+  totalCount: number;
+}
+
+const getQuoteRequest = async (
+  page = 1,
+  limit = 3
+): Promise<QuoteRequestPagination> => {
+  try {
+    const res = await apiClient.get("/quote", { params: { page, limit } });
+    return res as unknown as QuoteRequestPagination;
+  } catch (err) {
+    console.error("無法上傳資料:", err);
+    throw err;
+  }
+};
+const updateQuoteRequest = async (
+  id: number,
+  staffReply: string,
+  price: number
+) => {
+  try {
+    const res = await apiClient.post("/quote/update", {
+      id,
+      staffReply,
+      price,
+    });
+    return res;
+  } catch (err) {
+    console.error("無法上傳資料:", err);
+    throw err;
+  }
+};
+
+export { getQuoteRequest, updateQuoteRequest };

--- a/frontend/src/components/features/managementSection/Appointment.vue
+++ b/frontend/src/components/features/managementSection/Appointment.vue
@@ -41,7 +41,7 @@
   <section>
     <div class="font-serif text-2xl font-bold">
       <el-table :data="filteredList">
-        <el-table-column label="日期" prop="date" sortable />
+        <el-table-column label="日期" prop="date" sortable min-width="100" />
         <el-table-column label="開始時間" prop="startTime" sortable />
         <el-table-column label="結束時間" prop="endTime" sortable />
         <el-table-column label="會員" prop="member" sortable />
@@ -75,7 +75,7 @@
             </div>
           </template>
         </el-table-column>
-        <el-table-column label="加購數量" min-width="150">
+        <el-table-column label="加購數量">
           <template #default="{ row }">
             <div class="flex flex-col items-start gap-1">
               <el-tag
@@ -90,7 +90,12 @@
           </template>
         </el-table-column>
         <el-table-column label="金額" prop="total_price" sortable />
-        <el-table-column label="狀態" sortable :sort-method="sortByStatus">
+        <el-table-column
+          label="狀態"
+          sortable
+          :sort-method="sortByStatus"
+          min-width="150"
+        >
           <template #default="{ row }">
             <div class="flex items-center gap-1">
               <span
@@ -195,6 +200,7 @@ const fetchData = async () => {
   try {
     const res = await getAppointmentByTime(
       queryDate,
+      false,
       currentPage.value,
       pageSize.value
     );

--- a/frontend/src/components/features/managementSection/Dashboard.vue
+++ b/frontend/src/components/features/managementSection/Dashboard.vue
@@ -1,6 +1,305 @@
 <template>
+  <section class="p-4">
+    <div class="mb-4 flex items-center justify-between">
+      <div class="text-2xl font-bold font-serif">當日預約</div>
+
+      <div class="flex items-center gap-2">
+        <div>
+          <!-- 無障礙設計需要表單欄位元素具有id或name屬性並有label與表單欄位對應，tailwind有sr-only屬性讓label標籤在畫面上隱藏但保留無障礙功能 -->
+          <label for="admin-search" class="sr-only">搜尋預約</label>
+          <el-input
+            id="admin-search"
+            v-model="searchQuery"
+            placeholder="搜尋會員、美甲師或狀態..."
+            clearable
+            class="w-64!"
+          >
+            <template #prefix>
+              <span class="material-symbols-outlined text-gray-400"
+                >search</span
+              >
+            </template>
+          </el-input>
+        </div>
+
+        <el-button @click="clearQuery" circle>
+          <span class="material-symbols-outlined text-base">refresh</span>
+        </el-button>
+      </div>
+    </div>
+  </section>
   <section>
-    <div>1</div>
+    <div class="font-serif text-2xl font-bold">
+      <el-table :data="filteredList">
+        <el-table-column label="日期" prop="date" sortable min-width="100" />
+        <el-table-column label="開始時間" prop="startTime" sortable />
+        <el-table-column label="結束時間" prop="endTime" sortable />
+        <el-table-column label="會員" prop="member" sortable />
+        <el-table-column label="美甲師" prop="stylist" sortable />
+        <el-table-column label="備註" prop="note" sortable />
+        <el-table-column label="預約項目" min-width="150">
+          <template #default="{ row }">
+            <div class="flex flex-col items-start gap-1">
+              <el-tag
+                v-for="(item, index) in row.items"
+                :key="index"
+                size="small"
+                type="danger"
+              >
+                {{ item }}
+              </el-tag>
+            </div>
+          </template>
+        </el-table-column>
+        <el-table-column label="加購項目" min-width="150">
+          <template #default="{ row }">
+            <div class="flex flex-col items-start gap-1">
+              <el-tag
+                v-for="(addon, index) in row.addons"
+                :key="index"
+                size="small"
+                type="danger"
+              >
+                {{ addon }}
+              </el-tag>
+            </div>
+          </template>
+        </el-table-column>
+        <el-table-column label="加購數量">
+          <template #default="{ row }">
+            <div class="flex flex-col items-start gap-1">
+              <el-tag
+                v-for="(quantity, index) in row.quantity"
+                :key="index"
+                size="small"
+                type="danger"
+              >
+                {{ quantity }}
+              </el-tag>
+            </div>
+          </template>
+        </el-table-column>
+        <el-table-column label="金額" prop="total_price" sortable />
+        <el-table-column
+          label="狀態"
+          sortable
+          :sort-method="sortByStatus"
+          min-width="150"
+        >
+          <template #default="{ row }">
+            <div class="flex items-center gap-1">
+              <span
+                class="material-symbols-outlined text-base"
+                :class="statusMap[row.status]?.color"
+              >
+                {{ statusMap[row.status]?.icon }}
+              </span>
+              <el-select
+                :id="'status-select-' + row.id"
+                v-model="row.status"
+                placeholder="請選擇狀態"
+                size="small"
+                @change="(newStatus:string) => handleStatusChange(row.id, newStatus)"
+                :class="statusMap[row.status]?.color"
+                :disabled="!['pending', 'confirmed'].includes(row.status)"
+              >
+                <el-option
+                  v-for="(config, key) in statusMap"
+                  :key="key"
+                  :label="config.label"
+                  :value="key"
+                >
+                  <span
+                    class="material-symbols-outlined align-middle"
+                    :class="config.color"
+                  >
+                    {{ config.icon }}
+                  </span>
+                  <span :class="config.color">{{ config.label }}</span>
+                </el-option>
+              </el-select>
+            </div>
+          </template>
+        </el-table-column>
+      </el-table>
+    </div>
+    <el-pagination
+      v-model:current-page="currentPage"
+      v-model:page-size="pageSize"
+      :total="totalCount"
+      :page-sizes="[10, 20, 50]"
+      layout="total, sizes, prev, pager, next, jumper"
+      @size-change="handleSizeChange"
+      @current-change="handlePageChange"
+      class="mt-5"
+    />
   </section>
 </template>
-<script setup lang="ts"></script>
+<script setup lang="ts">
+import { computed, onMounted, ref } from "vue";
+import {
+  adminChangeStatus,
+  getAppointmentByTime,
+  type AppointmentItem,
+  type AppointmentList,
+} from "../../../api/appointment";
+import { ElMessage } from "element-plus";
+
+export interface FilteredList {
+  date: string;
+  startTime: string;
+  endTime: string;
+  member: string;
+  stylist: string;
+  items: AppointmentItem[];
+  price: number;
+  status: string;
+  statusColor: string;
+  note: string;
+}
+
+const appointmentList = ref<AppointmentList[]>([]);
+const searchQuery = ref<string>("");
+const totalCount = ref(0);
+const currentPage = ref(1);
+const pageSize = ref(10);
+const currentDays = ref(1);
+
+const statusMap: Record<
+  string,
+  { label: string; color: string; icon: string }
+> = {
+  pending: { label: "待確認", color: "text-orange-500", icon: "hourglass_top" },
+  confirmed: { label: "已確認", color: "text-blue-500", icon: "add_ad" },
+  completed: {
+    label: "已完成",
+    color: "text-green-500",
+    icon: "playlist_add_check",
+  },
+  cancelled: {
+    label: "已取消",
+    color: "text-gray-400",
+    icon: "receipt_long_off",
+  },
+  noshow: { label: "未到場", color: "text-red-500", icon: "visibility_off" },
+};
+
+const fetchData = async () => {
+  const msOfDay = currentDays.value * 24 * 60 * 60 * 1000;
+  const queryDate = new Date(Date.now() - msOfDay);
+
+  try {
+    const res = await getAppointmentByTime(
+      queryDate,
+      true,
+      currentPage.value,
+      pageSize.value
+    );
+    if (res) {
+      appointmentList.value = res.data;
+      totalCount.value = res.pagination.total;
+    }
+  } catch (err) {
+    ElMessage.error("載入資料失敗");
+  }
+};
+
+const handlePageChange = (page: number) => {
+  currentPage.value = page;
+  fetchData();
+};
+
+const handleSizeChange = (size: number) => {
+  pageSize.value = size;
+  currentPage.value = 1;
+  fetchData();
+};
+
+onMounted(() => fetchData());
+
+const filteredList = computed(() => {
+  if (!appointmentList.value) return [];
+
+  const formattedData = appointmentList.value.map((appointment) => {
+    const start = appointment.start_time
+      ? new Date(appointment.start_time)
+      : new Date();
+    const end = appointment.end_time
+      ? new Date(appointment.end_time)
+      : new Date();
+
+    return {
+      ...appointment,
+      date: appointment.start_time?.split("T")[0] || "",
+      startTime: `${start.getHours().toString().padStart(2, "0")}:${start
+        .getMinutes()
+        .toString()
+        .padStart(2, "0")}`,
+      endTime: `${end.getHours().toString().padStart(2, "0")}:${end
+        .getMinutes()
+        .toString()
+        .padStart(2, "0")}`,
+
+      member: appointment.users?.name || "未知會員",
+      stylist: appointment.staff?.name || "未指定",
+      items:
+        appointment.appointment_items?.map((i) => i.service_price?.label) || [],
+
+      addons:
+        appointment.appointment_items?.flatMap(
+          (item) =>
+            item.appointment_addons?.map((a) => a.service_addons?.name || "") ||
+            []
+        ) || [],
+      quantity: appointment.appointment_items?.flatMap(
+        (item) => item.appointment_addons?.map((a) => a.quantity || 0) || []
+      ),
+
+      price: appointment.total_price,
+      status: appointment.status,
+    };
+  });
+
+  if (!searchQuery.value.trim()) return formattedData;
+  const query = searchQuery.value.toLowerCase().trim();
+
+  return formattedData.filter((item) => {
+    return (
+      item.member.toLowerCase().includes(query) ||
+      item.stylist.toLowerCase().includes(query) ||
+      statusMap[item.status]?.label.includes(query) ||
+      item.items.some((label) => label?.toLowerCase().includes(query)) ||
+      item.date.includes(query)
+    );
+  });
+});
+
+const clearQuery = () => {
+  searchQuery.value = "";
+};
+
+const handleStatusChange = async (id: number, newStatus: string) => {
+  try {
+    await adminChangeStatus(id, newStatus);
+    ElMessage.success({
+      message: `狀態已成功更新為：${statusMap[newStatus]?.label}`,
+      type: "success",
+    });
+    await fetchData();
+  } catch (error) {
+    ElMessage.error("更新失敗，請稍後再試");
+    await fetchData();
+  }
+};
+
+const sortByStatus = (a: FilteredList, b: FilteredList) => {
+  const statusOrder = [
+    "pending",
+    "confirmed",
+    "completed",
+    "cancelled",
+    "noshow",
+  ];
+  return statusOrder.indexOf(a.status) - statusOrder.indexOf(b.status);
+};
+</script>

--- a/frontend/src/components/features/managementSection/Quote.vue
+++ b/frontend/src/components/features/managementSection/Quote.vue
@@ -1,0 +1,213 @@
+<template>
+  <section class="p-4 font-serif">
+    <div class="text-2xl font-bold">傳圖詢價確認</div>
+    <div class="flex justify-center items-center gap-5 mt-5">
+      <div
+        v-for="quote in recentQuoteRequest?.data"
+        :key="quote.id"
+        class="w-1/4"
+      >
+        <el-card>
+          <template #header>
+            <div>會員名稱：{{ quote.users.name }}</div>
+            <div>日期：{{ quote.appointments.start_time }}</div>
+            <div>選擇美甲師：{{ stylistMap[quote.staff_id] }}</div>
+            <div>款式敘述：{{ quote.description }}</div>
+
+            <div class="flex mt-2">
+              <span
+                class="material-symbols-outlined text-base"
+                :class="statusMap[quote.status]?.color"
+              >
+                {{ statusMap[quote.status]?.icon }}
+              </span>
+              <el-select
+                :id="'status-select-' + quote.id"
+                v-model="quote.status"
+                placeholder="請選擇狀態"
+                size="small"
+                @change="(newStatus:string) => handleStatusChange(quote.appointment_id, newStatus)"
+                :class="statusMap[quote.status]?.color"
+                :disabled="
+                  !['pending', 'confirmed'].includes(quote.appointments.status)
+                "
+              >
+                <el-option
+                  v-for="(config, key) in statusMap"
+                  :key="key"
+                  :label="config.label"
+                  :value="key"
+                >
+                  <span
+                    class="material-symbols-outlined align-middle"
+                    :class="config.color"
+                  >
+                    {{ config.icon }}
+                  </span>
+                  <span :class="config.color">{{ config.label }}</span>
+                </el-option>
+              </el-select>
+            </div>
+          </template>
+          <div class="relative w-full aspect-square overflow-hidden">
+            <img
+              :src="quote.image_url"
+              alt="詢價圖片"
+              class="absolute w-full h-full object-cover transition-transform duration-300 hover:scale-105 hover:cursor-pointer"
+              @click="handleDialogOpen(quote.image_url)"
+            />
+            <div>
+              <el-dialog v-model="centerDialogVisible" center align-center>
+                <div class="w-1/2 overflow-hidden mx-auto">
+                  <img
+                    :src="currentImage"
+                    alt="詢價圖片"
+                    class="max-w-full max-h-full"
+                  />
+                </div>
+              </el-dialog>
+            </div>
+          </div>
+
+          <div>
+            <div class="mt-2">回傳價格：</div>
+            <div class="flex justify-between gap-2 mt-2">
+              <el-input
+                v-model="quote.quoted_price"
+                placeholder="請輸入回傳價格"
+                show-word-limit
+                word-limit-position="outside"
+                type="number"
+              />
+            </div>
+          </div>
+          <template #footer>
+            報價訊息：
+            <el-input
+              v-model="quote.staff_reply"
+              placeholder="請輸入回傳訊息內容"
+              show-word-limit
+              word-limit-position="outside"
+              type="textarea"
+              class="mt-2"
+            />
+            <el-button
+              type="danger"
+              class="mt-5"
+              @click="
+                replyQuote(
+                  quote.appointment_id,
+                  quote.id,
+                  quote.staff_reply,
+                  quote.quoted_price
+                )
+              "
+              >確認價格與訊息</el-button
+            >
+          </template>
+        </el-card>
+      </div>
+    </div>
+    <el-pagination
+      v-model:current-page="currentPage"
+      :page-size="3"
+      layout="total, prev, pager, next"
+      :total="totalCount"
+      @current-change="handlePageChange"
+    />
+  </section>
+</template>
+<script setup lang="ts">
+import { onMounted, ref } from "vue";
+import { ElMessage } from "element-plus";
+import {
+  getQuoteRequest,
+  updateQuoteRequest,
+  type QuoteRequestPagination,
+} from "../../../api/quote";
+import { adminChangeStatus } from "../../../api/appointment";
+
+const recentQuoteRequest = ref<QuoteRequestPagination | null>(null);
+const totalCount = ref(0);
+const currentPage = ref(1);
+const pageSize = ref(3);
+const centerDialogVisible = ref(false);
+const currentImage = ref<string>("");
+const stylistMap: Record<number, string> = { 1: "阿柔", 2: "嫻嫻" };
+const statusMap: Record<
+  string,
+  { label: string; color: string; icon: string }
+> = {
+  pending: { label: "待確認", color: "text-orange-500", icon: "hourglass_top" },
+  confirmed: { label: "已確認", color: "text-blue-500", icon: "add_ad" },
+  completed: {
+    label: "已完成",
+    color: "text-green-500",
+    icon: "playlist_add_check",
+  },
+  cancelled: {
+    label: "已取消",
+    color: "text-gray-400",
+    icon: "receipt_long_off",
+  },
+  noshow: { label: "未到場", color: "text-red-500", icon: "visibility_off" },
+};
+
+const fetchQuoteData = async () => {
+  try {
+    const res = await getQuoteRequest(currentPage.value, pageSize.value);
+    recentQuoteRequest.value = res;
+    recentQuoteRequest.value.data.map((quote) => {
+      quote.appointments.start_time = new Date(
+        quote.appointments.start_time
+      ).toLocaleString("zh-TW", {
+        timeZone: "Asia/Taipei",
+        year: "numeric",
+        month: "2-digit",
+        day: "2-digit",
+        hour: "2-digit",
+        minute: "2-digit",
+      });
+    });
+    totalCount.value = res.totalCount;
+  } catch (err) {
+    ElMessage.error("載入資料失敗");
+  }
+};
+
+onMounted(() => fetchQuoteData());
+
+const handleDialogOpen = (imageUrl: string) => {
+  centerDialogVisible.value = true;
+  currentImage.value = imageUrl;
+};
+
+const handleStatusChange = async (id: number, newStatus: string) => {
+  try {
+    await adminChangeStatus(id, newStatus);
+    ElMessage.success({
+      message: `狀態已成功更新為：${statusMap[newStatus]?.label}`,
+      type: "success",
+    });
+    await fetchQuoteData();
+  } catch (error) {
+    ElMessage.error("更新失敗，請稍後再試");
+    await fetchQuoteData();
+  }
+};
+
+const replyQuote = async (
+  appointmentId: number,
+  id: number,
+  staffReply: string,
+  price: number
+) => {
+  await handleStatusChange(appointmentId, "confirmed");
+  await updateQuoteRequest(id, staffReply, price);
+  await fetchQuoteData();
+};
+const handlePageChange = (page: number) => {
+  currentPage.value = page;
+  fetchQuoteData();
+};
+</script>

--- a/frontend/src/views/Management.vue
+++ b/frontend/src/views/Management.vue
@@ -32,6 +32,7 @@
       <Membership v-if="currentPagination === 'membership'" />
       <Stylist v-if="currentPagination === 'stylist'" />
       <Gallery v-if="currentPagination === 'gallery'" />
+      <Quote v-if="currentPagination === 'quote'" />
     </div>
   </section>
 </template>
@@ -41,6 +42,7 @@ import Membership from "../components/features/managementSection/Membership.vue"
 import Stylist from "../components/features/managementSection/Stylist.vue";
 import Gallery from "../components/features/managementSection/Gallery.vue";
 import Dashboard from "../components/features/managementSection/Dashboard.vue";
+import Quote from "../components/features/managementSection/Quote.vue";
 import { ref } from "vue";
 
 const managementList = [
@@ -49,6 +51,7 @@ const managementList = [
   { name: "membership", zh_name: "會員管理" },
   { name: "stylist", zh_name: "美甲師管理" },
   { name: "gallery", zh_name: "當月款式管理" },
+  { name: "quote", zh_name: "傳圖詢價管理" },
 ];
 
 const currentPagination = ref("dashboard");

--- a/frontend/src/views/OrderRecords.vue
+++ b/frontend/src/views/OrderRecords.vue
@@ -107,7 +107,7 @@ const userStore = useUserStore();
 const appointmentStore = useAppointmentStore();
 const statusMap: Record<string, string> = {
   pending: "待確認",
-  confirmed: "已預約",
+  confirmed: "已確認",
   completed: "已完成",
   cancelled: "已取消",
   noshow: "未到店",


### PR DESCRIPTION
close #11 
1.管理主頁有當天的預約資訊，並可以更改狀態
<img width="1897" height="617" alt="image" src="https://github.com/user-attachments/assets/169eaee9-3e06-4347-8d53-bb54aec2eaf1" />

2.傳圖詢價區可對顧客傳圖詢價回報價格及訊息，並更改訂單的狀態及發送line通知
<img width="1477" height="756" alt="image" src="https://github.com/user-attachments/assets/f35a0ba2-0e12-4e78-95ec-9b1d8605858f" />
