### PR TITLE
fix: 修line登入沒有fetchUserProfile問題

### DIFF
--- a/frontend/src/composables/Login/useLineLogin.ts
+++ b/frontend/src/composables/Login/useLineLogin.ts
@@ -1,6 +1,7 @@
 import apiClient from "../../api/client";
 
 export const loginWithLine = async () => {
+  localStorage.setItem("is_logged_in", "true");
   const data = await apiClient.post(
     `auth/line/init`,
     {},


### PR DESCRIPTION
close #24 
修正line登入轉至首頁沒有辦法拿到使用者資料問題，起因於為解決一直跳出來的console.error，所以在fetchUserProfile加入這一段
const loggedIn = localStorage.getItem("is_logged_in");
    if (!loggedIn) return;
但原loginWithLine沒有設置is_logged_in，於是此次加入。
   